### PR TITLE
added setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="uwg",
+    version="0.0.1",
+    author="ladybug-tools",
+    description="The Urban Weather Generator engine for Urban Heat Island modelling",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/ladybug-tools/uwg",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 2.7",
+        "Operating System :: OS Independent",
+    ],
+)


### PR DESCRIPTION
In order to run and test Dragonfly we must pip install UWG. Adding setup.py allows pip to unpackage the library correctly. To pip install uwg you can run the following:
```bash
pip install https://github.com/ladybug-tools/uwg/archive/master.zip
```