### PR TITLE
added non .py dependencies to setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include uwg/refdata/*

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ladybug-tools/uwg",
     packages=setuptools.find_packages(),
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Forgot to add non python dependencies in the pip install setup.py file. Have added it now so it should include pickle files and such.