### PR TITLE
Import division from future

### DIFF
--- a/uwg/RSMDef.py
+++ b/uwg/RSMDef.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import os
 import math
 from pprint import pprint

--- a/uwg/UBLDef.py
+++ b/uwg/UBLDef.py
@@ -132,7 +132,7 @@ class UBLDef(object):
         ublTempdx[0] = (Csurf + advCoef1 + ublTempdx[0])/(1 + advCoef2)
         ublTemp = ublTempdx[0]
 
-        for i in xrange(1,int(charLength)/int(paralLength)):
+        for i in xrange(1,int(charLength)//int(paralLength)):
             eqTemp = ublTempdx[i-1]
             ublTempdx[i] = (Csurf + advCoef2*eqTemp + ublTempdx[i])/(1 + advCoef2)
             ublTemp = ublTemp + ublTempdx[i]

--- a/uwg/UBLDef.py
+++ b/uwg/UBLDef.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import logging
 
 class UBLDef(object):

--- a/uwg/UCMDef.py
+++ b/uwg/UCMDef.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from math import sqrt, pow
 import copy
 

--- a/uwg/UWG.py
+++ b/uwg/UWG.py
@@ -15,6 +15,7 @@ The urban weather generator, Journal of Building Performance Simulation. 6:4,269
 doi: 10.1080/19401493.2012.718797
 =========================================================================
 """
+from __future__ import division
 
 import os
 import math

--- a/uwg/building.py
+++ b/uwg/building.py
@@ -1,3 +1,4 @@
+from __future__ import division
 
 from psychrometrics import psychrometrics, moist_air_density
 import logging

--- a/uwg/element.py
+++ b/uwg/element.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import math
 import logging
 

--- a/uwg/forcing.py
+++ b/uwg/forcing.py
@@ -1,3 +1,6 @@
+from __future__ import division
+
+
 class Forcing (object):
     """
     FORCING

--- a/uwg/psychrometrics.py
+++ b/uwg/psychrometrics.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from math import log, pow, exp
 
 def psychrometrics (Tdb_in, w_in, P):

--- a/uwg/readDOE.py
+++ b/uwg/readDOE.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import sys
 import os
 import cPickle

--- a/uwg/simparam.py
+++ b/uwg/simparam.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import math
 
 class SimParam(object):

--- a/uwg/solarcalcs.py
+++ b/uwg/solarcalcs.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import math
 import logging
 

--- a/uwg/urbflux.py
+++ b/uwg/urbflux.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from infracalcs import infracalcs
 from math import log
 

--- a/uwg/uwg.py
+++ b/uwg/uwg.py
@@ -15,6 +15,7 @@ The urban weather generator, Journal of Building Performance Simulation. 6:4,269
 doi: 10.1080/19401493.2012.718797
 =========================================================================
 """
+from __future__ import division
 
 import os
 import math


### PR DESCRIPTION
I noticed some bugs in Dragonfly because I was testing with integer values and the divisions were not running as expected eg: [this stack overflow post](https://stackoverflow.com/questions/183853/in-python-2-what-is-the-difference-between-and-when-used-for-division).

I propose we always import divsion from __future__ and specifically use `\\` when we want to use integer division. Let me know what you think.

```python
from __future__ import division
```