### PR TITLE
feat(*): add python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
 # command to install dependencies
 #install:
 #	- pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
         "Operating System :: OS Independent",
     ],
 )

--- a/tests/test_RSMDef.py
+++ b/tests/test_RSMDef.py
@@ -1,7 +1,14 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
+from functools import reduce
+
 import pytest
 import uwg
 import math
-from test_base import TestBase
+from .test_base import TestBase
 
 from pprint import pprint
 from decimal import Decimal
@@ -73,7 +80,7 @@ class TestRSMDef(TestBase):
         assert self.uwg.RSM.presProf[0] == pytest.approx(1.009e5, abs=1e-15)
         assert self.uwg.RSM.presProf[-1] == pytest.approx(0.990802481868362e5, abs=1e-10)
         # Test all
-        for i in xrange(1,len(matlab_presProf)-1):
+        for i in range(1,len(matlab_presProf)-1):
             tol = self.CALCULATE_TOLERANCE(matlab_presProf[i]*1e5,15.0)
             assert self.uwg.RSM.presProf[i] == pytest.approx(matlab_presProf[i]*1e5, abs=tol)
 
@@ -90,7 +97,7 @@ class TestRSMDef(TestBase):
         1.173056716134468,1.171904800590439,1.170638479118457,1.169246475901031,
         1.167716422060640,1.166034753626033,1.165110236615915]
 
-        for i in xrange(len(matlab_densityProfS)):
+        for i in range(len(matlab_densityProfS)):
             tol = self.CALCULATE_TOLERANCE(matlab_densityProfS[i]*1e5,15.0)
             assert self.uwg.RSM.densityProfS[i] == pytest.approx(matlab_densityProfS[i], abs=tol)
 
@@ -149,7 +156,7 @@ class TestRSMDef(TestBase):
         # Matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             tol = self.CALCULATE_TOLERANCE(uwg_python_val[i],15.0)
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=tol), "error at index={}".format(i)
@@ -193,7 +200,7 @@ class TestRSMDef(TestBase):
         # Matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             tol = self.CALCULATE_TOLERANCE(uwg_python_val[i],11.0)
             #print dd(uwg_python_val[i])
             #print dd(uwg_matlab_val[i])

--- a/tests/test_UBLDef.py
+++ b/tests/test_UBLDef.py
@@ -1,10 +1,17 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
+from functools import reduce
+
 import pytest
 import uwg
 import os
 import math
 import pprint
 import decimal
-from test_base import TestBase
+from .test_base import TestBase
 
 dd = decimal.Decimal.from_float
 
@@ -37,7 +44,7 @@ class TestUBLDef(TestBase):
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val), "matlab={}, python={}".format(len(uwg_matlab_val), len(uwg_python_val))
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             tol = self.CALCULATE_TOLERANCE(uwg_python_val[i],15.0)
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], tol), "error at index={}".format(i)
@@ -85,7 +92,7 @@ class TestUBLDef(TestBase):
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             tol = self.CALCULATE_TOLERANCE(uwg_python_val[i],15.0)
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], tol), "error at index={}".format(i)

--- a/tests/test_UCMDef.py
+++ b/tests/test_UCMDef.py
@@ -1,10 +1,15 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
 import pytest
 import uwg
 import os
 import math
 import pprint
 import decimal
-from test_base import TestBase
+from .test_base import TestBase
 
 dd = decimal.Decimal.from_float
 
@@ -57,7 +62,7 @@ class TestUCMDef(TestBase):
 
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             tol = self.CALCULATE_TOLERANCE(uwg_python_val[i],15.0)
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], tol), "error at index={}".format(i)
@@ -121,7 +126,7 @@ class TestUCMDef(TestBase):
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             tol = self.CALCULATE_TOLERANCE(abs(uwg_python_val[i]),15.0)
             tol = 10**(math.log10(tol)+2) # Lowering tolerance by two orders of magnitude
             #print '-'*int(-(-15-math.log10(tol)))+'.123456789012345', tol

--- a/tests/test_UWG.py
+++ b/tests/test_UWG.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import uwg
 import math
-from test_base import TestBase
+from .test_base import TestBase
 
 from pprint import pprint
 from decimal import Decimal
@@ -48,8 +48,8 @@ class TestUWG(TestBase):
         self.uwg.init_input_obj()
 
         #test uwg param dictionary first and last
-        assert self.uwg._init_param_dict.has_key('bldHeight') == True
-        assert self.uwg._init_param_dict.has_key('h_obs') == True
+        assert 'bldHeight' in self.uwg._init_param_dict
+        assert 'h_obs' in self.uwg._init_param_dict
 
         assert self.uwg._init_param_dict['bldHeight'] == pytest.approx(10., abs=1e-6)
         assert self.uwg._init_param_dict['vegEnd'] == pytest.approx(10, abs=1e-6)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,6 +3,7 @@ import uwg
 import math
 import logging
 
+
 class TestBase(object):
     """
     Test base class. This is inherited by all other tests.

--- a/tests/test_bem.py
+++ b/tests/test_bem.py
@@ -1,11 +1,17 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
 import pytest
 import os
 import math
 import uwg
-from test_base import TestBase
+from .test_base import TestBase
 import pprint
 
 pp = pprint.pprint
+
 
 class TestBEM(TestBase):
 
@@ -55,7 +61,7 @@ class TestBEM(TestBase):
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             if type(uwg_python_val[i]) == type("a"):
                 assert "".join(uwg_python_val[i].split()) == "".join(uwg_matlab_val[i].split()), "error at index={}".format(i)
@@ -140,7 +146,7 @@ class TestBEM(TestBase):
         #matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print i, uwg_python_val[i], ' == ', uwg_matlab_val[i]
             tol = self.CALCULATE_TOLERANCE(uwg_python_val[i],15.0)
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=tol), "error at index={}".format(i)

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -1,9 +1,15 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
 import pytest
 import uwg
 import os
 import math
 import pprint
-from test_base import TestBase
+from .test_base import TestBase
+
 
 class TestElement(TestBase):
 
@@ -114,7 +120,7 @@ class TestElement(TestBase):
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             tol = self.CALCULATE_TOLERANCE(uwg_matlab_val[i],15.0)
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=tol), "error at index={}".format(i)
@@ -166,7 +172,7 @@ class TestElement(TestBase):
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             tol = self.CALCULATE_TOLERANCE(uwg_matlab_val[i],15.0)
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=tol), "error at index={}".format(i)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,8 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
 import pytest
 import uwg
 import os
@@ -7,7 +12,7 @@ import decimal
 
 import logging
 
-from test_base import TestBase
+from .test_base import TestBase
 
 dd = decimal.Decimal.from_float
 pp = pprint.pprint
@@ -33,7 +38,7 @@ class TestOutput(TestBase):
 
         assert len(pywtr.staTemp) == pytest.approx(len(matwtr.staTemp), abs=1e-15)
 
-        for i in xrange(0,len(pywtr.staTemp)):
+        for i in range(0,len(pywtr.staTemp)):
 
             # Check dry bulb [K]
             tol = self.CALCULATE_TOLERANCE(pywtr.staTemp[i],precision)

--- a/tests/test_psychrometrics.py
+++ b/tests/test_psychrometrics.py
@@ -8,6 +8,7 @@ import decimal
 dd = decimal.Decimal.from_float
 pp = pprint.pprint
 
+
 def test_psychrometric_float_point():
 
     # Input values
@@ -23,6 +24,7 @@ def test_psychrometric_float_point():
     assert h == pytest.approx(7.183036653518451e+04, abs=1e-15) # enthalpy [J/kgd]
     assert Tdp == pytest.approx(-10.012150181172135, abs=1e-15) # Wet bulb temp [C]
     assert v == pytest.approx(8.717031296493113, abs=1e-15)     # specific volume [m3/kga]s
+
 
 def test_psychrometric_simple_1():
     # Really simple, coarse tests

--- a/tests/test_readDOE.py
+++ b/tests/test_readDOE.py
@@ -1,15 +1,23 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
+from functools import reduce
+
 import pytest
 import os
 import copy
 import math
 
 import uwg
-from test_base import TestBase
+from .test_base import TestBase
 
 from pprint import pprint
 from decimal import Decimal
 dd = Decimal.from_float
 pp = pprint
+
 
 class TestReadDOE(TestBase):
     """Test for readDOE.py
@@ -78,7 +86,7 @@ class TestReadDOE(TestBase):
             'fanMax'
             ]
 
-        for bi in xrange(len(bldlst)):
+        for bi in range(len(bldlst)):
             bldid = bldlst[bi]
             matlab_path = os.path.join(self.DIR_MATLAB_PATH,"matlab_ref_{}_.txt".format(bldid))
             # check file exists
@@ -89,15 +97,15 @@ class TestReadDOE(TestBase):
 
             assert len(refDOE) == pytest.approx(16.0, abs=1e-3)
 
-            for bldType in xrange(16):         # bldType
+            for bldType in range(16):         # bldType
                 assert len(refDOE[bldType]) == pytest.approx(3.0, abs=1e-3)
 
-                for bldEra in xrange(3):        # bltEra
+                for bldEra in range(3):        # bltEra
                     assert len(refDOE[bldType][bldEra]) == pytest.approx(16.0, abs=1e-3)
 
-                    for climateZone in xrange(16):  # ZoneType
+                    for climateZone in range(16):  # ZoneType
 
-                        matlab_ref_value = matlab_file.next()
+                        matlab_ref_value = matlab_file.readline()
 
                         if bldid != 'condType':
                             matlab_ref_value = float(matlab_ref_value)
@@ -234,8 +242,8 @@ class TestReadDOE(TestBase):
         ("roof", copy.deepcopy(elementlst))
         ]
 
-        for bemi in xrange(len(bemlst)):
-            for ei in xrange(len(elementlst)):
+        for bemi in range(len(bemlst)):
+            for ei in range(len(elementlst)):
                 bemid = bemlst[bemi][0] + "_" + bemlst[bemi][1][ei]
 
                 matlab_path = os.path.join(self.DIR_MATLAB_PATH,"matlab_ref_bemdef_{}.txt".format(bemid))
@@ -247,15 +255,15 @@ class TestReadDOE(TestBase):
 
                 assert len(refBEM) == pytest.approx(16.0, abs=1e-3)
 
-                for bldType in xrange(16):         # bldType
+                for bldType in range(16):         # bldType
                     assert len(refBEM[bldType]) == pytest.approx(3.0, abs=1e-3)
 
-                    for bldEra in xrange(3):        # bltEra
+                    for bldEra in range(3):        # bltEra
                         assert len(refBEM[bldType][bldEra]) == pytest.approx(16.0, abs=1e-3)
 
-                        for climateZone in xrange(16):  # ZoneType
+                        for climateZone in range(16):  # ZoneType
                             # next line
-                            matlab_ref_value = float(matlab_file.next())
+                            matlab_ref_value = float(matlab_file.readline())
                             tol = self.CALCULATE_TOLERANCE(matlab_ref_value,15.0)
 
                             # run tests
@@ -382,7 +390,7 @@ class TestReadDOE(TestBase):
         'Vswh'
         ]
 
-        for si in xrange(len(schlst)):
+        for si in range(len(schlst)):
             schid = schlst[si]
 
             # Define file path
@@ -395,16 +403,16 @@ class TestReadDOE(TestBase):
 
             assert len(Schedule) == pytest.approx(16.0, abs=1e-3)
 
-            for bldType in xrange(1): # bldType
+            for bldType in range(1): # bldType
                 assert len(Schedule[bldType]) == pytest.approx(3.0, abs=1e-3)
 
-                for bldEra in xrange(1): # bltEra
+                for bldEra in range(1): # bltEra
                     assert len(Schedule[bldType][bldEra]) == pytest.approx(16.0, abs=1e-3)
 
-                    for climateZone in xrange(1): # ZoneType
+                    for climateZone in range(1): # ZoneType
 
                         if schid in schlst[:7]: #3x24 matrix of schedule for SWH (WD,Sat,Sun)
-                            matlab_ref_str = matlab_file.next()
+                            matlab_ref_str = matlab_file.readline()
                             # replace [,] -> "" && split at " "
                             matlab_ref_str = matlab_ref_str.replace("[","").replace("]","").replace(";","_").replace(" ", "_")
                             matlab_ref_str = "".join(matlab_ref_str.split())
@@ -416,7 +424,7 @@ class TestReadDOE(TestBase):
                             # Calculate tolerances and set minimum one for all
                             tol = min([self.CALCULATE_TOLERANCE(x,15.0) for x in matlab_ref_value])
                         else:
-                            matlab_ref_value = float(matlab_file.next())
+                            matlab_ref_value = float(matlab_file.readline())
                             tol = self.CALCULATE_TOLERANCE(matlab_ref_value,15.0)
 
                         if schid == 'Elec': #3x24 matrix of schedule for SWH (WD,Sat,Sun)

--- a/tests/test_simparam.py
+++ b/tests/test_simparam.py
@@ -1,9 +1,15 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
 import pytest
 import uwg
 import os
 import math
 import pprint
-from test_base import TestBase
+from .test_base import TestBase
+
 
 class TestSimParam(TestBase):
 
@@ -48,7 +54,7 @@ class TestSimParam(TestBase):
 
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=1e-15), "error at index={}".format(i)
 
@@ -88,7 +94,7 @@ class TestSimParam(TestBase):
 
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=1e-15), "error at index={}".format(i)
 
@@ -110,7 +116,7 @@ class TestSimParam(TestBase):
         assert simTime.nt == pytest.approx(2017,abs=1e-6)
 
         # Test UpdateDate() for < 1 hr
-        for i in xrange(11): #11 * 300 = 3300 seconds = 55min
+        for i in range(11): #11 * 300 = 3300 seconds = 55min
             simTime.UpdateDate()
         assert simTime.secDay == pytest.approx(3300., abs=1e-6)
         assert simTime.day == pytest.approx(30., abs=1e-6)
@@ -120,14 +126,14 @@ class TestSimParam(TestBase):
         assert simTime.secDay == pytest.approx(3600., abs=1e-6)
         assert simTime.hourDay == pytest.approx(1., abs=1e-6)
         # for > 24hr
-        for i in xrange(23 * 12):
+        for i in range(23 * 12):
             simTime.UpdateDate()
         assert simTime.secDay == pytest.approx(0., abs=1e-6)
         assert simTime.day == pytest.approx(31., abs=1e-6)
         assert simTime.hourDay == pytest.approx(0., abs=1e-6)
 
         # for == 1 month
-        for i in xrange(24 * 12):
+        for i in range(24 * 12):
             simTime.UpdateDate()
         assert simTime.secDay == pytest.approx(0., abs=1e-6)
         assert simTime.day == pytest.approx(1., abs=1e-6)
@@ -135,7 +141,7 @@ class TestSimParam(TestBase):
         assert simTime.month == pytest.approx(8, abs=1e-6)
 
         # for + 1 month
-        for i in xrange(24 * 12 * 31):
+        for i in range(24 * 12 * 31):
             simTime.UpdateDate()
         assert simTime.secDay == pytest.approx(0., abs=1e-6)
         assert simTime.day == pytest.approx(1., abs=1e-6)

--- a/tests/test_solarcalcs.py
+++ b/tests/test_solarcalcs.py
@@ -1,9 +1,14 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
 import pytest
 import uwg
 import os
 import math
 import pprint
-from test_base import TestBase
+from .test_base import TestBase
 
 class TestSolarCalcs(TestBase):
 
@@ -21,7 +26,7 @@ class TestSolarCalcs(TestBase):
             self.uwg.forc, self.uwg.geoParam, self.uwg.rural)
 
         #timestep every 5 minutes (300s)
-        for i in xrange(int(12*24*1.5)): #1.5 days, Jan 2nd, 12 noon
+        for i in range(int(12*24*1.5)): #1.5 days, Jan 2nd, 12 noon
             solar.simTime.UpdateDate()
         solar.solarangles()
 
@@ -31,7 +36,7 @@ class TestSolarCalcs(TestBase):
         assert solar.ad == pytest.approx(0.197963373,abs=1e-8)
 
         # recalculate solar angles with new time simulation, add to previous time increment
-        for i in xrange(12*24*20 + 12*1 + 6): # Increment time to 22 days, 13hrs, 30min = Jan 22 at 1330
+        for i in range(12*24*20 + 12*1 + 6): # Increment time to 22 days, 13hrs, 30min = Jan 22 at 1330
             solar.simTime.UpdateDate()
 
         # Run simulation
@@ -56,7 +61,7 @@ class TestSolarCalcs(TestBase):
 
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=1e-15), "error at index={}".format(i)
 
@@ -111,7 +116,7 @@ class TestSolarCalcs(TestBase):
 
         # matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             #print uwg_python_val[i], uwg_matlab_val[i]
             assert uwg_python_val[i] == pytest.approx(uwg_matlab_val[i], abs=1e-15), "error at index={}".format(i)
 

--- a/tests/test_urbflux.py
+++ b/tests/test_urbflux.py
@@ -1,11 +1,17 @@
+try:
+    range = xrange
+except NameError:
+    pass
+
 import pytest
 import os
 import math
 import uwg
 import pprint
-from test_base import TestBase
+from .test_base import TestBase
 
 pp = pprint.pprint
+
 
 class TestUrbFlux(TestBase):
 
@@ -78,7 +84,7 @@ class TestUrbFlux(TestBase):
         #matlab ref checking
         assert len(uwg_matlab_val) == len(uwg_python_val)
 
-        for i in xrange(len(uwg_matlab_val)):
+        for i in range(len(uwg_matlab_val)):
             if uwg_matlab_val[i] == "\n":
                 uwg_matlab_val[i] = None
                 assert uwg_python_val[i] == uwg_matlab_val[i], "error at index={}".format(i)

--- a/uwg/BEMDef.py
+++ b/uwg/BEMDef.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 
 class BEMDef(object):
     """

--- a/uwg/RSMDef.py
+++ b/uwg/RSMDef.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 
 try:
     range = xrange

--- a/uwg/RSMDef.py
+++ b/uwg/RSMDef.py
@@ -1,10 +1,16 @@
 from __future__ import division
 
+try:
+    range = xrange
+except NameError:
+    pass
+
 import os
 import math
 from pprint import pprint
 
 ppr = pprint
+
 
 class RSMDef(object):
     """
@@ -54,7 +60,7 @@ class RSMDef(object):
         self.z  = [0 for x in range(len(self.z_meso)-1)] # Midht btwn each distance interval
         self.dz = [0 for x in range(len(self.z_meso)-1)] # Distance betweeen each interval
 
-        for zi in xrange(len(self.z_meso)-1):
+        for zi in range(len(self.z_meso)-1):
             self.z[zi] = 0.5 * (self.z_meso[zi] + self.z_meso[zi+1])
             self.dz[zi] = self.z_meso[zi+1] - self.z_meso[zi]
 
@@ -66,7 +72,7 @@ class RSMDef(object):
         pp = True
 
         # Define self.nz0, self.nzref, self.nzfor, self.nz10, self.nzi
-        for iz in xrange(len(self.z_meso)-1):
+        for iz in range(len(self.z_meso)-1):
             # self.nz0: self.z index >= reference height for weather station
             eq_th = self.is_near_zero(self.z[iz] - parameter.tempHeight)
             if (eq_th == True or self.z[iz] > parameter.tempHeight) and ll==True:
@@ -100,21 +106,21 @@ class RSMDef(object):
         self.tempProf = [T_init for x in range(self.nzref)]
         self.presProf = [P_init for x in range(self.nzref)]
 
-        for iz in xrange(1,self.nzref):
+        for iz in range(1,self.nzref):
             self.presProf[iz] = (self.presProf[iz-1]**(parameter.r/parameter.cp) -\
                parameter.g/parameter.cp * (P_init**(parameter.r/parameter.cp)) * (1./self.tempProf[iz] +\
                1./self.tempProf[iz-1]) * 0.5 * self.dz[iz])**(1./(parameter.r/parameter.cp))
 
         self.tempRealProf = [T_init for x in range(self.nzref)]
-        for iz in xrange(self.nzref):
+        for iz in range(self.nzref):
            self.tempRealProf[iz] = self.tempProf[iz] * (self.presProf[iz] / P_init)**(parameter.r/parameter.cp)
 
         self.densityProfC = [None for x in range(self.nzref)]
-        for iz in xrange(self.nzref):
+        for iz in range(self.nzref):
            self.densityProfC[iz] = self.presProf[iz] / parameter.r / self.tempRealProf[iz]
 
         self.densityProfS = [self.densityProfC[0] for x in range(self.nzref+1)]
-        for iz in xrange(1,self.nzref):
+        for iz in range(1,self.nzref):
            self.densityProfS[iz] = (self.densityProfC[iz] * self.dz[iz-1] +\
                self.densityProfC[iz-1] * self.dz[iz]) / (self.dz[iz-1]+self.dz[iz])
 
@@ -154,23 +160,23 @@ class RSMDef(object):
         self.tempProf[0] = forc.temp    # Lower boundary condition
 
         # compute pressure profile
-        for iz in reversed(range(self.nzref)[1:]):
+        for iz in reversed(list(range(self.nzref))[1:]):
            self.presProf[iz-1] = (math.pow(self.presProf[iz],parameter.r/parameter.cp) + \
                parameter.g/parameter.cp*(math.pow(forc.pres,parameter.r/parameter.cp)) * \
                (1./self.tempProf[iz] + 1./self.tempProf[iz-1]) * \
                0.5 * self.dz[iz])**(1./(parameter.r/parameter.cp))
 
         # compute the real temperature profile
-        for iz in xrange(self.nzref):
+        for iz in range(self.nzref):
             self.tempRealProf[iz]= self.tempProf[iz] * \
             (self.presProf[iz]/forc.pres)**(parameter.r/parameter.cp)
 
         # compute the density profile
-        for iz in xrange(self.nzref):
+        for iz in range(self.nzref):
            self.densityProfC[iz] = self.presProf[iz]/parameter.r/self.tempRealProf[iz]
         self.densityProfS[0] = self.densityProfC[0]
 
-        for iz in xrange(1,self.nzref):
+        for iz in range(1,self.nzref):
            self.densityProfS[iz] = (self.densityProfC[iz] * self.dz[iz-1] + \
                self.densityProfC[iz-1] * self.dz[iz])/(self.dz[iz-1] + self.dz[iz])
 
@@ -193,25 +199,25 @@ class RSMDef(object):
         # log(-x) = log(x) + log(-1) = log(x) + i*pi
         # Python will throw an exception. Negative value occurs here if
         # VDM is run for average obstacle height ~ 4m.
-        for iz in xrange(self.nzref):
+        for iz in range(self.nzref):
             self.windProf[iz] = ustarRur/parameter.vk*\
                 math.log((self.z[iz]-self.disp)/self.z0r)
 
         # Average pressure
         self.ublPres = 0.
-        for iz in xrange(self.nzfor):
+        for iz in range(self.nzfor):
             self.ublPres = self.ublPres + \
                 self.presProf[iz]*self.dz[iz]/(self.z[self.nzref-1]+self.dz[self.nzref-1]/2.)
 
     def DiffusionEquation(self,nz,dt,co,da,daz,cd,dz):
 
-        cddz = [0 for i in xrange(nz+2)]
-        a = [[0 for j in xrange(3)] for i in xrange(nz)]
-        c = [0 for i in xrange(nz)]
+        cddz = [0 for i in range(nz+2)]
+        a = [[0 for j in range(3)] for i in range(nz)]
+        c = [0 for i in range(nz)]
 
         #--------------------------------------------------------------------------
         cddz[0] = daz[0]*cd[0]/dz[0]
-        for iz in xrange(1,nz):
+        for iz in range(1,nz):
             cddz[iz] = 2.*daz[iz]*cd[iz]/(dz[iz]+dz[iz-1])
         cddz[nz] = daz[nz]*cd[nz]/dz[nz]
         #--------------------------------------------------------------------------
@@ -220,7 +226,7 @@ class RSMDef(object):
         a[0][2] = 0.
         c[0] = co[0]
 
-        for iz in xrange(1,nz-1):
+        for iz in range(1,nz-1):
             dzv = dz[iz]
             a[iz][0]=-cddz[iz]*dt/dzv/da[iz]
             a[iz][1]=1+dt*(cddz[iz]+cddz[iz+1])/dzv/da[iz]
@@ -238,9 +244,9 @@ class RSMDef(object):
 
     def DiffusionCoefficient(self,rho,z,dz,z0,disp,tempRur,heatRur,nz,uref,th,parameter):
         # Initialization
-        Kt = [0 for x in xrange(nz+1)]
-        ws = [0 for x in xrange(nz)]
-        te = [0 for x in xrange(nz)]
+        Kt = [0 for x in range(nz+1)]
+        ws = [0 for x in range(nz)]
+        te = [0 for x in range(nz)]
         # Friction velocity (Louis 1979)
         ustar = parameter.vk * uref/math.log((10.-disp)/z0)
 
@@ -254,14 +260,14 @@ class RSMDef(object):
             # Wind profile function
             phi_m = (1-8.*0.1*parameter.dayBLHeight/lengthRur)**(-1./3.)
 
-            for iz in xrange(nz):
+            for iz in range(nz):
                 # Mixed-layer velocity scale
                 ws[iz] = (ustar**3 + phi_m*parameter.vk*wstar**3*z[iz]/parameter.dayBLHeight)**(1/3.)
                 # TKE approximation
                 te[iz] = max(ws[iz]**2., 0.01)
 
         else: # Stable and neutral conditions
-            for iz in xrange(nz):
+            for iz in range(nz):
                 # TKE approximation
                 te[iz] = max(ustar**2.,0.01)
 
@@ -271,7 +277,7 @@ class RSMDef(object):
         self.dld,dls,dlk = self.LengthBougeault(nz,self.dld,self.dlu,z)
 
         # Boundary-layer diffusion coefficient
-        for iz in xrange(nz):
+        for iz in range(nz):
            Kt[iz] = 0.4*dlk[iz]*math.sqrt(te[iz])
 
         Kt[nz] = Kt[nz-1]
@@ -283,17 +289,17 @@ class RSMDef(object):
         # list length (i.e nz) != list indexing (i.e dlu[0] in python
         # wherease in matlab it is
 
-        dlu = [0 for x in xrange(nz)]
-        dld = [0 for x in xrange(nz)]
+        dlu = [0 for x in range(nz)]
+        dld = [0 for x in range(nz)]
 
-        for iz in xrange(nz):
+        for iz in range(nz):
             zup=0.
             dlu[iz] = z[nz] - z[iz] - dz[iz]/2.
             zzz=0.
             zup_inf=0.
             beta=g/pt[iz]
 
-            for izz in xrange(iz,nz-1):
+            for izz in range(iz,nz-1):
                 dzt=(dz[izz+1]+dz[izz])/2.
                 zup=zup-beta*pt[iz]*dzt
                 zup=zup+beta*(pt[izz+1]+pt[izz])*dzt/2.
@@ -316,7 +322,7 @@ class RSMDef(object):
             dld[iz]=z[iz]+dz[iz]/2.
             zzz=0.
 
-            for izz in xrange(iz,0,-1):
+            for izz in range(iz,0,-1):
                 dzt=(dz[izz-1]+dz[izz])/2.
                 zdo=zdo+beta*pt[iz]*dzt
                 zdo=zdo-beta*(pt[izz-1]+pt[izz])*dzt/2.
@@ -338,14 +344,14 @@ class RSMDef(object):
 
     def LengthBougeault(self,nz,dld,dlu,z):
 
-        dlg = [0 for x in xrange(nz)]
-        dls = [0 for x in xrange(nz)]
-        dlk = [0 for x in xrange(nz)]
+        dlg = [0 for x in range(nz)]
+        dls = [0 for x in range(nz)]
+        dlk = [0 for x in range(nz)]
 
-        for iz in xrange(nz):
+        for iz in range(nz):
             dlg[iz] = (z[iz]+z[iz+1])/2.
 
-        for iz in xrange(nz):
+        for iz in range(nz):
             dld[iz] = min(dld[iz], dlg[iz])
             dls[iz] = math.sqrt(dlu[iz]*dld[iz])
             dlk[iz] = min(dlu[iz],dld[iz])
@@ -366,16 +372,16 @@ class RSMDef(object):
          x     results
         """
 
-        X = [0 for i in xrange(nz)]
+        X = [0 for i in range(nz)]
 
-        for i in reversed(xrange(nz-1)):
+        for i in reversed(range(nz-1)):
             C[i] = C[i] - A[i][2] * C[i+1]/A[i+1][1]
             A[i][1] = A[i][1] - A[i][2] * A[i+1][0]/A[i+1][1]
 
-        for i in  xrange(1,nz,1):
+        for i in  range(1,nz,1):
             C[i] = C[i] - A[i][0] * C[i-1]/A[i-1][1]
 
-        for i in xrange(nz):
+        for i in range(nz):
             X[i] = C[i]/A[i][1]
 
         return X

--- a/uwg/UBLDef.py
+++ b/uwg/UBLDef.py
@@ -1,6 +1,12 @@
 from __future__ import division
 
+try:
+    range = xrange
+except NameError:
+    pass
+
 import logging
+
 
 class UBLDef(object):
     """
@@ -62,11 +68,11 @@ class UBLDef(object):
 
         # Air density
         refDens = 0.
-        for iz in xrange(RSM.nzref):
+        for iz in range(RSM.nzref):
             refDens = refDens + RSM.densityProfC[iz] * RSM.dz[iz] / (RSM.z[RSM.nzref-1] + RSM.dz[RSM.nzref-1]/2.)
 
         forDens = 0.
-        for iz in xrange(RSM.nzfor):
+        for iz in range(RSM.nzfor):
             forDens = forDens + RSM.densityProfC[iz] * RSM.dz[iz] / (RSM.z[RSM.nzfor-1] + RSM.dz[RSM.nzfor-1]/2.)
 
         # ---------------------------------------------------------------------
@@ -94,11 +100,11 @@ class UBLDef(object):
             if v_wind > u_circ:   # Forced problem (usually this)
                 advCoef  = self.orthLength*eqWind*simTime.dt/self.urbArea*1.4
                 self.ublTemp = (Csurf + advCoef * eqTemp + self.ublTemp)/(1. + advCoef)
-                self.ublTempdx = [self.ublTemp for x in xrange(len(self.ublTempdx))]
+                self.ublTempdx = [self.ublTemp for x in range(len(self.ublTempdx))]
             else:                   # Convective problem
                 advCoef  = self.perimeter*u_circ*simTime.dt/self.urbArea*1.4
                 self.ublTemp = (Csurf+advCoef*eqTemp + self.ublTemp)/(1 + advCoef)
-                self.ublTempdx = [self.ublTemp for x in xrange(len(self.ublTempdx))]
+                self.ublTempdx = [self.ublTemp for x in range(len(self.ublTempdx))]
 
 
 
@@ -118,13 +124,13 @@ class UBLDef(object):
         # Night forcing (RSM.nzfor = number of layers of forcing)
         # Average potential temperature & wind speed of the profile
         intAdv1 = 0.
-        for iz in xrange(RSM.nzfor):
+        for iz in range(RSM.nzfor):
             intAdv1 = intAdv1 + RSM.windProf[iz] * RSM.tempProf[iz] * RSM.dz[iz]
 
         advCoef1 = 1.4*dt/paralLength/h_UBL*intAdv1
 
         intAdv2 = 0
-        for iz in xrange(RSM.nzfor):
+        for iz in range(RSM.nzfor):
             intAdv2 = intAdv2 + RSM.windProf[iz]*RSM.dz[iz]
 
         advCoef2 = 1.4*dt/paralLength/h_UBL*intAdv2
@@ -132,7 +138,7 @@ class UBLDef(object):
         ublTempdx[0] = (Csurf + advCoef1 + ublTempdx[0])/(1 + advCoef2)
         ublTemp = ublTempdx[0]
 
-        for i in xrange(1,int(charLength)//int(paralLength)):
+        for i in range(1,int(charLength)//int(paralLength)):
             eqTemp = ublTempdx[i-1]
             ublTempdx[i] = (Csurf + advCoef2*eqTemp + ublTempdx[i])/(1 + advCoef2)
             ublTemp = ublTemp + ublTempdx[i]

--- a/uwg/UCMDef.py
+++ b/uwg/UCMDef.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 
 try:
     range = xrange

--- a/uwg/UCMDef.py
+++ b/uwg/UCMDef.py
@@ -1,7 +1,13 @@
 from __future__ import division
 
+try:
+    range = xrange
+except NameError:
+    pass
+
 from math import sqrt, pow
 import copy
+
 
 class UCMDef(object):
     """
@@ -171,7 +177,7 @@ class UCMDef(object):
         Q = (self.roofArea+self.roadArea)*(self.sensAnthrop + self.treeSensHeat*self.treeCoverage)
 
         # Building energy output to canyon, in terms of absolute (total) values
-        for j in xrange(len(BEM)):
+        for j in range(len(BEM)):
             # Re-naming variable for readability
             building = BEM[j].building
             wall = BEM[j].wall
@@ -213,7 +219,7 @@ class UCMDef(object):
 
         # Building energy output to canyon, per m^2 of urban area
         T_can = copy.copy(self.canTemp)
-        for j in xrange(len(BEM)):
+        for j in range(len(BEM)):
             V_vent = BEM[j].building.vent*BEM[j].building.nFloor  # ventilation volume per m^2 of building
             V_infil = BEM[j].building.infil*self.bldHeight/3600.0
             T_indoor = BEM[j].building.indoorTemp

--- a/uwg/UWG.py
+++ b/uwg/UWG.py
@@ -16,6 +16,7 @@ doi: 10.1080/19401493.2012.718797
 =========================================================================
 """
 from __future__ import division
+from __future__ import print_function
 
 import os
 import math

--- a/uwg/UWG.py
+++ b/uwg/UWG.py
@@ -19,28 +19,31 @@ from __future__ import division
 
 import os
 import math
-import cPickle
 import copy
 import utilities
 import logging
 
-from simparam import SimParam
-from weather import Weather
-from building import Building
-from material import Material
-from element import Element
-from BEMDef import BEMDef
-from schdef import SchDef
-from param import Param
-from UCMDef import UCMDef
-from forcing import Forcing
-from UBLDef import UBLDef
-from RSMDef import RSMDef
-from solarcalcs import SolarCalcs
-import urbflux
-from psychrometrics import psychrometrics
-from readDOE import readDOE
-from urbflux import urbflux
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+from .simparam import SimParam
+from .weather import Weather
+from .building import Building
+from .material import Material
+from .element import Element
+from .BEMDef import BEMDef
+from .schdef import SchDef
+from .param import Param
+from .UCMDef import UCMDef
+from .forcing import Forcing
+from .UBLDef import UBLDef
+from .RSMDef import RSMDef
+from .solarcalcs import SolarCalcs
+from .psychrometrics import psychrometrics
+from .readDOE import readDOE
+from .urbflux import urbflux
 
 # For debugging only
 #from pprint import pprint
@@ -431,10 +434,10 @@ class uwg(object):
         # If a uwgParamFileName is set, then read inputs from .uwg file.
         # User-defined class properties will override the inputs from the .uwg file.
         if self.uwgParamFileName is not None:
-            print "\nReading uwg file input."
+            print("\nReading uwg file input.")
             self.read_input()
         else:
-            print "\nNo .uwg file input."
+            print("\nNo .uwg file input.")
 
         # Required parameters
         is_defined = (type(self.Month) == float or type(self.Month) == int) and \
@@ -485,9 +488,9 @@ class uwg(object):
             raise Exception("readDOE.pkl file: '{}' does not exist.".format(readDOE_file_path))
 
         readDOE_file = open(self.readDOE_file_path, 'rb')  # open pickle file in binary form
-        refDOE = cPickle.load(readDOE_file)
-        refBEM = cPickle.load(readDOE_file)
-        refSchedule = cPickle.load(readDOE_file)
+        refDOE = pickle.load(readDOE_file)
+        refBEM = pickle.load(readDOE_file)
+        refSchedule = pickle.load(readDOE_file)
         readDOE_file.close()
 
         # Define building energy models
@@ -688,7 +691,7 @@ class uwg(object):
         self.RSMData = [None for x in xrange(self.N)]
         self.USMData = [None for x in xrange(self.N)]
 
-        print '\nSimulating new temperature and humidity values for {} days from {}/{}.\n'.format(
+        print('\nSimulating new temperature and humidity values for {} days from {}/{}.\n').format(
             int(self.nDay), int(self.Month), int(self.Day))
         self.logger.info("Start simulation")
 
@@ -885,7 +888,7 @@ class uwg(object):
 
         epw_new_id.close()
 
-        print "New climate file '{}' is generated at {}.".format(
+        print("New climate file '{}' is generated at {}.".format(
             self.destinationFileName, self.destinationDir)
 
     def run(self):
@@ -921,7 +924,7 @@ def procMat(materials, max_thickness, min_thickness):
                     newthickness.append(materials.layerThickness[j]/float(nlayers))
             # Material that's less then min_thickness is not added.
             elif materials.layerThickness[j] < min_thickness:
-                print "WARNING: Material '{}' layer found too thin (<{:.2f}cm), ignored.".format(
+                print("WARNING: Material '{}' layer found too thin (<{:.2f}cm), ignored.").format(
                     materials._name, min_thickness*100)
             else:
                 newmat.append(Material(k[j], Vhc[j], name=materials._name))
@@ -941,7 +944,7 @@ def procMat(materials, max_thickness, min_thickness):
             newthickness = [min_thickness/2., min_thickness/2.]
             newmat = [Material(k[0], Vhc[0], name=materials._name),
                       Material(k[0], Vhc[0], name=materials._name)]
-            print "WARNING: a thin (<2cm) single material '{}' layer found. May cause error.".format(
+            print("WARNING: a thin (<2cm) single material '{}' layer found. May cause error.".format(
                 materials._name)
         else:
             newthickness = [materials.layerThickness[0]/2., materials.layerThickness[0]/2.]

--- a/uwg/__init__.py
+++ b/uwg/__init__.py
@@ -1,25 +1,25 @@
 """Urban Weather Generator Library."""
 
-from simparam import SimParam
-from weather import  Weather
-from building import Building
-from material import Material
-from element import Element
-from BEMDef import BEMDef
-from schdef import SchDef
-from param import Param
-from UCMDef import UCMDef
-from forcing import Forcing
-from UBLDef import UBLDef
-from RSMDef import RSMDef
-from solarcalcs import SolarCalcs
+from .simparam import SimParam
+from .weather import Weather
+from .building import Building
+from .material import Material
+from .element import Element
+from .BEMDef import BEMDef
+from .schdef import SchDef
+from .param import Param
+from .UCMDef import UCMDef
+from .forcing import Forcing
+from .UBLDef import UBLDef
+from .RSMDef import RSMDef
+from .solarcalcs import SolarCalcs
 
-from readDOE import readDOE
-from infracalcs import infracalcs
-from urbflux import urbflux
+from .readDOE import readDOE
+from .infracalcs import infracalcs
+from .urbflux import urbflux
 
-from uwg import uwg
-from uwg import procMat
+from .uwg import uwg
+from .uwg import procMat
 
 
 __all__ = [

--- a/uwg/building.py
+++ b/uwg/building.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-from psychrometrics import psychrometrics, moist_air_density
+from .psychrometrics import psychrometrics, moist_air_density
 import logging
 from math import isnan
 import sys

--- a/uwg/building.py
+++ b/uwg/building.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 
 from .psychrometrics import psychrometrics, moist_air_density
 import logging

--- a/uwg/element.py
+++ b/uwg/element.py
@@ -1,7 +1,12 @@
 from __future__ import division
 
+try:
+    range = xrange
+except NameError:
+    pass
+
 import math
-import logging
+
 
 class Element(object):
     """
@@ -50,7 +55,7 @@ class Element(object):
             self.layerVolHeat = [0. for i in materialLst]           # vector of layer volumetric heat (J m-3 K-1)
 
             # Create list of layer k and (Cp*density) from materialLst properties
-            for i in xrange(len(materialLst)):
+            for i in range(len(materialLst)):
               self.layerThermalCond[i] = materialLst[i].thermalCond
               self.layerVolHeat[i] = materialLst[i].volHeat
 
@@ -173,18 +178,18 @@ class Element(object):
         num = len(t)                # number of layers
 
         # Mean thermal conductivity over distance between 2 layers (W/mK)
-        tcp = [0 for x in xrange(num)]
+        tcp = [0 for x in range(num)]
         # Thermal capacity times layer depth (J/m2K)
-        hcp = [0 for x in xrange(num)]
+        hcp = [0 for x in range(num)]
         # lower, main, and upper diagonals
-        za = [[0 for y in xrange(3)] for x in xrange(num)]
+        za = [[0 for y in range(3)] for x in range(num)]
         # RHS
-        zy = [0 for x in xrange(num)]
+        zy = [0 for x in range(num)]
 
         #--------------------------------------------------------------------------
         # Define the column vectors for heat capactiy and conductivity
         hcp[0] = hc[0] * d[0]
-        for j in xrange(1,num):
+        for j in range(1,num):
             tcp[j] = 2. / (d[j-1] / tc[j-1] + d[j] / tc[j])
             hcp[j] = hc[j] * d[j]
 
@@ -197,7 +202,7 @@ class Element(object):
 
         #--------------------------------------------------------------------------
         # Define other rows
-        for j in xrange(1,num-1):
+        for j in range(1,num-1):
           za[j][0] = fimp*(-tcp[j])
           za[j][1] = hcp[j]/dt + fimp*(tcp[j]+tcp[j+1])
           za[j][2] = fimp*(-tcp[j+1])
@@ -235,11 +240,11 @@ class Element(object):
         betaw = (parameter.lvtt/parameter.rv) + (gamw * parameter.tt)
         alpw = math.log(parameter.estt) + (betaw /parameter.tt) + (gamw * math.log(parameter.tt))
         work2 = parameter.r/parameter.rv
-        foes_lst = [0 for i in xrange(len(temp))]
-        work1_lst = [0 for i in xrange(len(temp))]
-        qsat_lst = [0 for i in xrange(len(temp))]
+        foes_lst = [0 for i in range(len(temp))]
+        work1_lst = [0 for i in range(len(temp))]
+        qsat_lst = [0 for i in range(len(temp))]
 
-        for i in xrange(len(temp)):
+        for i in range(len(temp)):
           # saturation vapor pressure
           foes_lst[i] = math.exp( alpw - betaw/temp[i] - gamw*math.log(temp[i])  )
           work1_lst[i] = foes_lst[i]/pres[i]
@@ -263,16 +268,16 @@ class Element(object):
          x     results
         """
 
-        X = [0 for i in xrange(nz)]
+        X = [0 for i in range(nz)]
 
-        for i in reversed(xrange(nz-1)):
+        for i in reversed(range(nz-1)):
             C[i] = C[i] - A[i][2] * C[i+1]/A[i+1][1]
             A[i][1] = A[i][1] - A[i][2] * A[i+1][0]/A[i+1][1]
 
-        for i in  xrange(1,nz,1):
+        for i in  range(1,nz,1):
             C[i] = C[i] - A[i][0] * C[i-1]/A[i-1][1]
 
-        for i in xrange(nz):
+        for i in range(nz):
             X[i] = C[i]/A[i][1]
 
         return X

--- a/uwg/material.py
+++ b/uwg/material.py
@@ -1,5 +1,6 @@
 """Material class"""
 
+
 class Material(object):
     """uwg Material
 
@@ -9,7 +10,7 @@ class Material(object):
         name: Name of the material.
     """
     def __init__(self, thermalCond, volHeat, name='noname'):
-        self._name = name # purely for internal purpose
+        self._name = name  # purely for internal purpose
         self.thermalCond = thermalCond
         self.volHeat = volHeat
 

--- a/uwg/psychrometrics.py
+++ b/uwg/psychrometrics.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 from math import log, pow, exp
 
+
 def psychrometrics (Tdb_in, w_in, P):
     """
     Modified version of Psychometrics by Tea Zakula

--- a/uwg/readDOE.py
+++ b/uwg/readDOE.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 
 try:
     range = xrange

--- a/uwg/readDOE.py
+++ b/uwg/readDOE.py
@@ -1,17 +1,24 @@
 from __future__ import division
 
+try:
+    range = xrange
+except NameError:
+    pass
+
 import sys
 import os
-import cPickle
 
-from building import Building
-from material import Material
-from element import Element
-from BEMDef import BEMDef
-from schdef import SchDef
-from utilities import read_csv, str2fl
-import utilities
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
+from .building import Building
+from .material import Material
+from .element import Element
+from .BEMDef import BEMDef
+from .schdef import SchDef
+from .utilities import read_csv, str2fl
 
 # For debugging only
 #import pprint
@@ -68,6 +75,7 @@ ZONETYPE = [
     '8 (Fairbanks)'             # 16
     ]
 
+
 def readDOE(serialize_output=True):
     """
     Read csv files of DOE buildings
@@ -105,13 +113,13 @@ def readDOE(serialize_output=True):
     """
 
     #Nested, nested lists of Building, SchDef, BEMDef objects
-    refDOE   = [[[None]*16 for k_ in xrange(3)] for j_ in xrange(16)]                #refDOE(16,3,16) = Building
-    Schedule = [[[None]*16 for k_ in xrange(3)] for j_ in xrange(16)]                #Schedule (16,3,16) = SchDef
-    refBEM   = [[[None]*16 for k_ in xrange(3)] for j_ in xrange(16)]                #refBEM (16,3,16) = BEMDef
+    refDOE   = [[[None]*16 for k_ in range(3)] for j_ in range(16)]                #refDOE(16,3,16) = Building
+    Schedule = [[[None]*16 for k_ in range(3)] for j_ in range(16)]                #Schedule (16,3,16) = SchDef
+    refBEM   = [[[None]*16 for k_ in range(3)] for j_ in range(16)]                #refBEM (16,3,16) = BEMDef
 
     #Purpose: Loop through every DOE reference csv and extract building data
     #Nested loop = 16 types, 3 era, 16 zones = time complexity O(n*m*k) = 768
-    for i in xrange(16):
+    for i in range(16):
 
         #i = 16 types of buildings
         #print "\tType: {} @i={}".format(BLDTYPE[i], i)
@@ -172,12 +180,12 @@ def readDOE(serialize_output=True):
         SchSWH      = str2fl([list_doe4[19][6:30],list_doe4[20][6:30],list_doe4[21][6:30]])   # Solar Water Heating Schedule 24 hrs; wkday=summerdesign, sat=winterdesgin
 
 
-        for j in xrange(3):
+        for j in range(3):
 
             # j = 3 built eras
             #print"\tEra: {} @j={}".format(BUILTERA[j], j)
 
-            for k in xrange(16):
+            for k in range(16):
 
                 # k = 16 climate zones
                 #print "\tClimate zone: {} @k={}".format(ZONETYPE[k], k)
@@ -357,9 +365,9 @@ def readDOE(serialize_output=True):
 
         # dump in ../resources
         # Pickle objects, protocol 1 b/c binary file
-        cPickle.dump(refDOE, pickle_readDOE,1)
-        cPickle.dump(refBEM, pickle_readDOE,1)
-        cPickle.dump(Schedule, pickle_readDOE,1)
+        pickle.dump(refDOE, pickle_readDOE,1)
+        pickle.dump(refBEM, pickle_readDOE,1)
+        pickle.dump(Schedule, pickle_readDOE,1)
 
         pickle_readDOE.close()
 

--- a/uwg/simparam.py
+++ b/uwg/simparam.py
@@ -1,6 +1,12 @@
 from __future__ import division
 
+try:
+    range = xrange
+except NameError:
+    pass
+
 import math
+
 
 class SimParam(object):
     """
@@ -64,7 +70,7 @@ class SimParam(object):
             self.day += 1
             self.julian = self.julian + 1
             self.secDay = 0.
-            for j in xrange(12):
+            for j in range(12):
                 if self.is_near_zero(self.julian - self.inobis[j]):
                     self.month = self.month + 1
                     self.day = 1

--- a/uwg/simparam.py
+++ b/uwg/simparam.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 
 try:
     range = xrange

--- a/uwg/solarcalcs.py
+++ b/uwg/solarcalcs.py
@@ -1,7 +1,13 @@
 from __future__ import division
 
+try:
+    range = xrange
+except NameError:
+    pass
+
 import math
 import logging
+
 
 class SolarCalcs(object):
     """
@@ -101,7 +107,7 @@ class SolarCalcs(object):
             # Receiving solar, including bounces (W m-2)
             self.UCM.road.solRec = self.roadSol + (1 - self.UCM.roadConf)*self.mw
 
-            for j in xrange(len(self.BEM)):
+            for j in range(len(self.BEM)):
                 self.BEM[j].roof.solRec = self.horSol + self.dif
                 self.BEM[j].wall.solRec = self.bldSol + (1 - 2*self.UCM.wallConf) * self.mw + self.UCM.wallConf * self.mr
 
@@ -121,7 +127,7 @@ class SolarCalcs(object):
             self.UCM.road.solRec = 0.
             self.rural.solRec = 0.
 
-            for j in xrange(len(self.BEM)):
+            for j in range(len(self.BEM)):
                 self.BEM[j].roof.solRec = 0.
                 self.BEM[j].wall.solRec = 0.
 
@@ -166,9 +172,9 @@ class SolarCalcs(object):
         GMT = self.RSM.GMT
 
         self.ut = (24. + (int(secDay)/3600.%24.)) % 24. # Get elapsed hours on current day
-        ibis = range(len(inobis))
+        ibis = list(range(len(inobis)))
 
-        for JI in xrange(1,12):
+        for JI in range(1, 12):
              ibis[JI] = inobis[JI]+1
 
         date = day + inobis[month-1]-1 # Julian day of the year

--- a/uwg/urbflux.py
+++ b/uwg/urbflux.py
@@ -1,7 +1,13 @@
 from __future__ import division
 
-from infracalcs import infracalcs
+try:
+    range = xrange
+except NameError:
+    pass
+
+from .infracalcs import infracalcs
 from math import log
+
 
 def urbflux(UCM, UBL, BEM, forc, parameter, simTime, RSM):
     """
@@ -15,7 +21,7 @@ def urbflux(UCM, UBL, BEM, forc, parameter, simTime, RSM):
     UCM.roofTemp = 0.       # Average urban roof temperature
     UCM.wallTemp = 0.       # Average urban wall temperature
 
-    for j in xrange(len(BEM)):
+    for j in range(len(BEM)):
         # Building energy model
         BEM[j].building.BEMCalc(UCM, BEM[j], forc, parameter, simTime)
         BEM[j].ElecTotal = BEM[j].building.ElecTotal * BEM[j].fl_area # W m-2
@@ -70,7 +76,7 @@ def urbflux(UCM, UBL, BEM, forc, parameter, simTime, RSM):
     c2 = 0.0
     c3 = 0.0
 
-    for iz in xrange(RSM.nzfor):
+    for iz in range(RSM.nzfor):
         # At c loss of precision at at low order of magnitude, that we need in UBL.advHeat calc
         # Algebraically t is 0, but with floating pt numbers c will accumulate truncated values
         y = RSM.densityProfC[iz]*RSM.dz[iz]/(RSM.z[RSM.nzfor-1] + RSM.dz[RSM.nzfor-1]/2.)
@@ -123,7 +129,7 @@ def urbflux(UCM, UBL, BEM, forc, parameter, simTime, RSM):
     UCM.turbW = 1.3*UCM.ustarMod
 
     # Urban wind profile
-    for iz in xrange(RSM.nzref):
+    for iz in range(RSM.nzref):
         UCM.windProf.append(UCM.ustar/parameter.vk*\
             log((RSM.z[iz]+UCM.bldHeight-UCM.l_disp)/UCM.z0u))
 

--- a/uwg/utilities.py
+++ b/uwg/utilities.py
@@ -1,6 +1,13 @@
 """Collection of useful methods."""
 import os
 from csv import reader as csv_reader
+import sys
+
+try:
+    range = xrange
+except NameError:
+    pass
+
 
 def zeros(h, w):
     """create a (h x w) matrix of zeros.
@@ -11,10 +18,15 @@ def zeros(h, w):
     """
     return [[0 for x in range(w)] for y in range(h)]
 
+
 def read_csv(file_name_):
     # open csv file and read
     if os.path.exists(file_name_):
-        file_ = open(file_name_,"r")
+        if sys.version_info[0] >= 3:
+            file_ = open(file_name_, "r", errors='ignore')
+        else:
+            file_ = open(file_name_, "r")
+
         gen_ = csv_reader(file_, delimiter=",")
         L = [r for r in gen_]
         file_.close()
@@ -22,8 +34,10 @@ def read_csv(file_name_):
     else:
         raise Exception("File name: '{}' does not exist.".format(file_name_))
 
+
 def is_near_zero(num, eps=1e-10):
     return abs(num) < eps
+
 
 def str2fl(x):
     """Recurses through lists and converts lists of string to float
@@ -36,7 +50,7 @@ def str2fl(x):
         if s_ == "":
             return "null"
         elif "," in s_:
-            s_ = s_.replace("," , "")
+            s_ = s_.replace(",", "")
 
         try:
             return float(s_)
@@ -44,11 +58,11 @@ def str2fl(x):
             return (s_)
 
     fl_lst = []
-    if isinstance(x[0], basestring):                # Check if list of strings, then sent to conversion
-        for xi in xrange(len(x)):
+    if isinstance(x[0], str):                # Check if list of strings, then sent to conversion
+        for xi in range(len(x)):
             fl_lst.append(helper_to_fl(x[xi]))
-    elif type(x[0]) == type([]):                    # Check if list of lists, then recurse
-        for xi in xrange(len(x)):
+    elif isinstance(x[0], list):                    # Check if list of lists, then recurse
+        for xi in range(len(x)):
             fl_lst.append(str2fl(x[xi]))
     else:
         return False

--- a/uwg/uwg.py
+++ b/uwg/uwg.py
@@ -16,6 +16,8 @@ doi: 10.1080/19401493.2012.718797
 =========================================================================
 """
 from __future__ import division
+from __future__ import print_function
+
 from functools import reduce
 
 try:

--- a/uwg/weather.py
+++ b/uwg/weather.py
@@ -1,6 +1,12 @@
-from utilities import read_csv, str2fl
+from .utilities import read_csv, str2fl
 from math import pow, log, exp
-from psychrometrics import HumFromRHumTemp
+from .psychrometrics import HumFromRHumTemp
+
+try:
+    range = xrange
+except NameError:
+    pass
+
 
 class Weather(object):
     """
@@ -36,19 +42,19 @@ class Weather(object):
 
         self.location = self.climate_data[0][1]
         cd = self.climate_data[HI:HF+1]
-        self.staTemp = str2fl([cd[i][6] for i in xrange(len(cd))])           # drybulb [C]
-        self.staTdp = str2fl([cd[i][7] for i in xrange(len(cd))])            # dewpoint [C]
-        self.staRhum = str2fl([cd[i][8] for i in xrange(len(cd))])           # air relative humidity (%)
-        self.staPres = str2fl([cd[i][9] for i in xrange(len(cd))])           # air pressure (Pa)
-        self.staInfra = str2fl([cd[i][12] for i in xrange(len(cd))])         # horizontal Infrared Radiation Intensity (W m-2)
-        self.staHor = str2fl([cd[i][13] for i in xrange(len(cd))])           # horizontal radiation [W m-2]
-        self.staDir = str2fl([cd[i][14] for i in xrange(len(cd))])           # normal solar direct radiation (W m-2)
-        self.staDif = str2fl([cd[i][15] for i in xrange(len(cd))])           # horizontal solar diffuse radiation (W m-2)
-        self.staUdir = str2fl([cd[i][20] for i in xrange(len(cd))])          # wind direction ()
-        self.staUmod = str2fl([cd[i][21] for i in xrange(len(cd))])          # wind speed (m s-1)
-        self.staRobs = str2fl([cd[i][33] for i in xrange(len(cd))])          # Precipitation (mm h-1)
+        self.staTemp = str2fl([cd[i][6] for i in range(len(cd))])           # drybulb [C]
+        self.staTdp = str2fl([cd[i][7] for i in range(len(cd))])            # dewpoint [C]
+        self.staRhum = str2fl([cd[i][8] for i in range(len(cd))])           # air relative humidity (%)
+        self.staPres = str2fl([cd[i][9] for i in range(len(cd))])           # air pressure (Pa)
+        self.staInfra = str2fl([cd[i][12] for i in range(len(cd))])         # horizontal Infrared Radiation Intensity (W m-2)
+        self.staHor = str2fl([cd[i][13] for i in range(len(cd))])           # horizontal radiation [W m-2]
+        self.staDir = str2fl([cd[i][14] for i in range(len(cd))])           # normal solar direct radiation (W m-2)
+        self.staDif = str2fl([cd[i][15] for i in range(len(cd))])           # horizontal solar diffuse radiation (W m-2)
+        self.staUdir = str2fl([cd[i][20] for i in range(len(cd))])          # wind direction ()
+        self.staUmod = str2fl([cd[i][21] for i in range(len(cd))])          # wind speed (m s-1)
+        self.staRobs = str2fl([cd[i][33] for i in range(len(cd))])          # Precipitation (mm h-1)
         self.staHum = [0.0] * len(self.staTemp)                                     # specific humidty (kgH20 kgN202-1)
-        for i in xrange(len(self.staTemp)):
+        for i in range(len(self.staTemp)):
             self.staHum[i] = HumFromRHumTemp(self.staRhum[i], self.staTemp[i], self.staPres[i])
 
         self.staTemp = [s+273.15 for s in self.staTemp]                             # air temperature (K)


### PR DESCRIPTION
In preparation for the [Python-pocalypse](https://pythonclock.org/) we should add python 3 support. This PR should solve [this issue](https://github.com/ladybug-tools/uwg/issues/75). Here is an initial proposal on how to do so. 

The main strategies involve the following:
1. `xrange` is replaced by variable name `range` and provided with backwards compatibility like so:
```python
try:
    range = xrange # Will work if running Python 2
except NameError:
    pass                  # If Python 3 can just use normal range
```
2. Printing like an adult 
```python
print("like an adult") # GOOD
print "like a child"     # BAD
```
3. Relative imports are used 
```python
import .local_file # GOOD
import local_file  # BAD
```
4. Importing division behaviour from Python 3 
```python
from __future__ import division
```
5. There was also a peculiar case of csv import errors with decrypting info in python 3 which I resolved in lines 25-28:
https://github.com/ladybug-tools/uwg/blob/03a328f44a05a4b2cd10e1bee18f2e4f76cae5f9/uwg/utilities.py#L22-L35