### PR TITLE
fix(solarcalcs): replace zenith with self.zenith

### DIFF
--- a/uwg/solarcalcs.py
+++ b/uwg/solarcalcs.py
@@ -203,7 +203,7 @@ class SolarCalcs(object):
             if(0.5*math.pi-self.zenith > 0.):
                 self.tanzen = math.tan(0.5*math.pi-1e-6);
 
-            if(0.5*math.pi-zenith <= 0.):
+            if(0.5*math.pi-self.zenith <= 0.):
                 self.tanzen = math.tan(0.5*math.pi+1e-6);
 
         elif (abs(self.zenith) <  1e-6):


### PR DESCRIPTION
Noticed this bug while running on local machine. Not sure why it wasn't picked up by tests or previous runs but here we have it!