### PR TITLE
fix(zone): Include support for ClimateZones 1B and 5C

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,16 +32,16 @@ def test_model_validate():
 
 def test_param_validate():
     """Test uwg validation."""
+    if (sys.version_info >= (3, 7)):
+        runner = CliRunner()
+        input_uwg = './tests/parameters/initialize_singapore.uwg'
+        result = runner.invoke(validate, ['param', input_uwg])
+        print(result.output)
+        assert result.exit_code == 0, result.output
 
-    runner = CliRunner()
-    input_uwg = './tests/parameters/initialize_singapore.uwg'
-    result = runner.invoke(validate, ['param', input_uwg])
-    print(result.output)
-    assert result.exit_code == 0, result.output
-
-    input_uwg = './tests/parameters/initialize_singapore_error.uwg'
-    result = runner.invoke(validate, ['param', input_uwg])
-    assert result.exit_code == 1, result.output
+        input_uwg = './tests/parameters/initialize_singapore_error.uwg'
+        result = runner.invoke(validate, ['param', input_uwg])
+        assert result.exit_code == 1, result.output
 
 
 def test_uwg_simulate():

--- a/uwg/cli/validate.py
+++ b/uwg/cli/validate.py
@@ -17,7 +17,7 @@ import json
 try:
     import uwg_schema.model as schema_model
 except ImportError:
-    print('uwg_schema is not installed. Try `pip install . [cli]` command.')
+    pass  # uwg_schema is not installed
 
 
 @click.group(help='Commands for validating UWG JSON and .uwg files.')
@@ -37,6 +37,11 @@ def validate_model(model_json):
             can be overridden by CLI arguments.
     """
     try:
+        try:
+            schema_model
+        except Exception:
+            raise ImportError(
+                'uwg_schema is not installed. Try `pip install . [cli]` command.')
         assert os.path.isfile(
             model_json), 'No JSON file found at {}.'.format(model_json)
 
@@ -66,6 +71,12 @@ def validate_param(param_uwg):
         param_uwg: Full path to a .uwg parameter file.
     """
     try:
+        try:
+            schema_model
+        except Exception:
+            raise ImportError(
+                'uwg_schema is not installed. Try `pip install . [cli]` command.')
+
         # validate the Model JSON
         click.echo('Validating .uwg parameter file ...')
         UWG.from_param_file(param_uwg)

--- a/uwg/utilities.py
+++ b/uwg/utilities.py
@@ -32,8 +32,8 @@ REF_BLDTYPE_SET = {'fullservicerestaurant', 'hospital', 'largehotel', 'largeoffi
                    'quickservicerestaurant', 'secondaryschool', 'smallhotel',
                    'smalloffice', 'standaloneretail', 'stripmall', 'supermarket',
                    'warehouse'}
-REF_ZONETYPE_SET = {'1A', '2A', '2B', '3A', '3B-CA', '3B', '3C', '4A', '4B', '4C', '5A',
-                    '5B', '6A', '6B', '7', '8'}
+REF_ZONETYPE_SET = {'1A', '1B', '2A', '2B', '3A', '3B-CA', '3B', '3C', '4A', '4B', '4C',
+                    '5A', '5B', '5C', '6A', '6B', '7', '8'}
 REF_BUILTERA_SET = {'pre80', 'pst80', 'new'}
 
 

--- a/uwg/uwg.py
+++ b/uwg/uwg.py
@@ -828,6 +828,7 @@ class UWG(object):
         Choose from the following:
 
         * '1A' - (i.e Miami)
+        * '1B' - (i.e Kuwait)
         * '2A' - (i.e Houston)
         * '2B' - (i.e Phoenix)
         * '3A' - (i.e Atlanta)
@@ -839,6 +840,7 @@ class UWG(object):
         * '4C' - (i.e Seattle)
         * '5A' - (i.e Chicago)
         * '5B' - (i.e Boulder)
+        * '5C' - (i.e Bremerton)
         * '6A' - (i.e Minneapolis)
         * '6B' - (i.e Helena)
         * '7' - (i.e Duluth)
@@ -851,7 +853,7 @@ class UWG(object):
         assert isinstance(value, str), \
             'zone must be a string. Got: {}.'.format(value)
         value = value.upper()
-        assert value in REF_ZONETYPE_SET, 'zone must be on of {}. Got: {}.'.format(
+        assert value in REF_ZONETYPE_SET, 'zone must be one of {}. Got: {}.'.format(
             REF_ZONETYPE, value)
         self._zone = value
 
@@ -1565,7 +1567,8 @@ class UWG(object):
         self.Sch = []  # list of Schedule objects
 
         # Modify zone to be used as python index
-        zone_idx = REF_ZONETYPE.index(self.zone)
+        bld_z = '1A' if self.zone == '1B' else '5B' if self.zone == '5C' else self.zone
+        zone_idx = REF_ZONETYPE.index(bld_z)
 
         # Build unique key based on bldtype and builtera strings
         bld_dict = {bldg[0] + bldg[1]: (bldg[0], REF_BUILTERA.index(bldg[1]), bldg[2])
@@ -1815,7 +1818,8 @@ class UWG(object):
                 the refSchedule matrix according to the SchDef bldtype and builtera
                 values.
         """
-        zi = REF_ZONETYPE.index(self.zone)
+        bld_z = '1A' if self.zone == '1B' else '5B' if self.zone == '5C' else self.zone
+        zi = REF_ZONETYPE.index(bld_z)
         # Insert or extend refSchedule matrix
         for sch in self.ref_sch_vector:
             ei = REF_BUILTERA.index(sch.builtera)


### PR DESCRIPTION
I assume that these climate zones were not originally included because there is no part of the contiguous US that contains them. However, they definitely exist on Earth and the ASHRAE 90.1 guidelines for them are effectively the same as other climate zones. So I am embedding this mapping with this commit.