### PR TITLE
fix(uwg): Handle the case of EPWs without all 34 fields

### DIFF
--- a/uwg/uwg.py
+++ b/uwg/uwg.py
@@ -1414,7 +1414,7 @@ class UWG(object):
 
         for i in range(len(self.epwinput)):
             printme = ''
-            for ei in range(34):
+            for ei in range(len(self.epwinput[i])):
                 printme += "{}".format(self.epwinput[i][ei]) + ','
             printme = printme + "{}".format(self.epwinput[i][ei])
             new_epw_line = '{0}\n'.format(printme)


### PR DESCRIPTION
It seems that some programs don't use all 34 fields in the EPW and the UWG is largely able to handle this except for the very last step of writing the EPW. This change fixes this.

More information can be found here:
https://discourse.ladybug.tools/t/2050-future-epw-data-could-not-be-morphed-by-df-tool/15242/2