### PR TITLE
fix(uwg): Loosen the check of bld fractions

### DIFF
--- a/tests/parameters/initialize_fatal_error.uwg
+++ b/tests/parameters/initialize_fatal_error.uwg
@@ -80,7 +80,7 @@ SchTraffic,
 # New
 
 bld,
-LargeOffice, Pst80, 0.64
+LargeOffice, Pst80, 0.66
 MidRiseApartment, Pst80, 0.221
 Warehouse, Pst80, 0.138
 

--- a/uwg/uwg.py
+++ b/uwg/uwg.py
@@ -793,7 +793,7 @@ class UWG(object):
                 'fraction of total built stock. Got: {}.'.format(frac)
             total_frac += frac
 
-        assert abs(total_frac - 1.0) < 1e-10, 'The sum of reference building ' \
+        assert abs(total_frac - 1.0) < 1e-2, 'The sum of reference building ' \
             'fractions defined in bld must equal one. Got: {}.'.format(
                 total_frac)
 


### PR DESCRIPTION
This is way too strict given Python floating point tolerance and the number of buildings we might have.