### PR TITLE
fix(RWMDef): Catch the case of math domain errors in wind profile

### DIFF
--- a/uwg/RSMDef.py
+++ b/uwg/RSMDef.py
@@ -215,9 +215,11 @@ class RSMDef(object):
         # Python will throw an exception. Negative value occurs here if
         # VDM is run for average obstacle height ~ 4m.
         for iz in range(self.nzref):
-            self.windProf[iz] = \
-                ustarRur / parameter.vk * \
-                log((self.z[iz] - self.disp) / self.z0r)
+            try:
+                self.windProf[iz] = ustarRur / parameter.vk * \
+                    log((self.z[iz] - self.disp) / self.z0r)
+            except ValueError:  # math domain error occurred
+                self.windProf[iz] = 0
 
         # Average pressure
         self.ublPres = 0.


### PR DESCRIPTION
It seems like the wind speed should just be interpreted as 0 in these cases where it's out of range of the log function.

More information here:
https://discourse.ladybug.tools/t/can-not-generate-a-uwg-epw-file/15155/6